### PR TITLE
v0.2.0

### DIFF
--- a/api.go
+++ b/api.go
@@ -132,11 +132,11 @@ func (a Api) doHTTPRequest(ctx context.Context, method, uri string, params url.V
 	return res, nil
 }
 
-func (a Api) checkHTTPStatus(desiredCode int, res *http.Response) error {
+func (a Api) checkHTTPStatusError(okCodes []int, res *http.Response) error {
 	var err error
 	var body []byte
 
-	if res.StatusCode != desiredCode {
+	if !isItemInSlice(okCodes, res.StatusCode) {
 		hdErr := &HiDriveError{}
 		if body, err = io.ReadAll(res.Body); err != nil {
 			return err

--- a/dir.go
+++ b/dir.go
@@ -72,7 +72,7 @@ func (d DirApi) GetDir(ctx context.Context, params url.Values) (*HiDriveObject, 
 		}
 	}
 
-	if err := d.checkHTTPStatus(http.StatusOK, res); err != nil {
+	if err := d.checkHTTPStatusError([]int{http.StatusOK}, res); err != nil {
 		return nil, err
 	}
 
@@ -132,7 +132,7 @@ func (d DirApi) CreateDir(ctx context.Context, params url.Values) (*HiDriveObjec
 		}
 	}
 
-	if err := d.checkHTTPStatus(http.StatusCreated, res); err != nil {
+	if err := d.checkHTTPStatusError([]int{http.StatusCreated}, res); err != nil {
 		return nil, err
 	}
 
@@ -218,7 +218,7 @@ func (d DirApi) DeleteDir(ctx context.Context, params url.Values) error {
 		}
 	}
 
-	if err := d.checkHTTPStatus(http.StatusNoContent, res); err != nil {
+	if err := d.checkHTTPStatusError([]int{http.StatusNoContent}, res); err != nil {
 		return err
 	}
 

--- a/file.go
+++ b/file.go
@@ -58,7 +58,7 @@ func (f FileApi) GetFile(ctx context.Context, params url.Values) (io.ReadCloser,
 		}
 	}
 
-	if err := f.checkHTTPStatus(http.StatusOK, res); err != nil {
+	if err := f.checkHTTPStatusError([]int{http.StatusOK}, res); err != nil {
 		return nil, err
 	}
 
@@ -120,7 +120,7 @@ func (f FileApi) UploadFile(ctx context.Context, params url.Values, fileBody io.
 		}
 	}
 
-	if err := f.checkHTTPStatus(http.StatusCreated, res); err != nil {
+	if err := f.checkHTTPStatusError([]int{http.StatusCreated}, res); err != nil {
 		return nil, err
 	}
 
@@ -172,7 +172,7 @@ func (f FileApi) DeleteFile(ctx context.Context, params url.Values) error {
 		}
 	}
 
-	if err := f.checkHTTPStatus(http.StatusNoContent, res); err != nil {
+	if err := f.checkHTTPStatusError([]int{http.StatusNoContent}, res); err != nil {
 		return err
 	}
 

--- a/params.go
+++ b/params.go
@@ -19,13 +19,13 @@ func NewParameters() *Parameters {
 SetPath adds "path" parameter to the query - path to a filesystem object
 
 Can be used in the following methods:
-  - DirApi.GetDir
-  - DirApi.CreateDir
-  - DirApi.DeleteDir
-  - FileApi.GetFile
-  - FileApi.DeleteFile
-  - ShareApi.GetShare
-  - ShareApi.CreateShare
+  - [DirApi.GetDir]
+  - [DirApi.CreateDir]
+  - [DirApi.DeleteDir]
+  - [FileApi.GetFile]
+  - [FileApi.DeleteFile]
+  - [ShareApi.GetShare]
+  - [ShareApi.CreateShare]
 */
 func (p *Parameters) SetPath(path string) *Parameters {
 	p.Set("path", path)
@@ -39,13 +39,13 @@ The public id is a path and encoding independent representation
 of a specific filesystem object. Also returned and referred to as id in data related responses.
 
 Can be used in the following methods:
-  - DirApi.GetDir
-  - DirApi.CreateDir
-  - DirApi.DeleteDir
-  - FileApi.GetFile
-  - FileApi.DeleteFile
-  - ShareApi.GetShare
-  - ShareApi.CreateShare
+  - [DirApi.GetDir]
+  - [DirApi.CreateDir]
+  - [DirApi.DeleteDir]
+  - [FileApi.GetFile]
+  - [FileApi.DeleteFile]
+  - [ShareApi.GetShare]
+  - [ShareApi.CreateShare]
 */
 func (p *Parameters) SetPid(pid string) *Parameters {
 	p.Set("pid", pid)
@@ -63,7 +63,7 @@ Valid values are:
   - symlink - include symlinks          (not in combination with none or all)
 
 Can be used in the following methods:
-  - DirApi.GetDir
+  - [DirApi.GetDir]
 */
 func (p *Parameters) SetMembers(members []string) *Parameters {
 	memStr := strings.Join(members, ",")
@@ -82,7 +82,7 @@ To get all directory entries it is always recommended to check the nmembers fiel
 A value of none or 0 for <limit> signifies to return as many entries as is feasible. This also works when combined with an offset.
 
 Can be used in the following methods:
-  - DirApi.GetDir
+  - [DirApi.GetDir]
 */
 func (p *Parameters) SetLimit(limit uint, offset uint) *Parameters {
 	p.Set("limit", fmt.Sprintf("%d,%d", offset, limit))
@@ -99,7 +99,7 @@ Can be used in the following methods:
   - DirApi.GetFile
   - ShareAPi.GetShare
 
-Valida values for DirApi.GetDir:
+Valid values for [DirApi.GetDir]:
   - category                - string    - object category (audio, image, etc.)
   - chash (*)               - string    - recursive hashvalue for the directory
   - ctime                   - timestamp - ctime of the object
@@ -150,7 +150,7 @@ Valida values for DirApi.GetDir:
   - shareable               - bool      - share-permission for the directory
   - teamfolder              - bool      - indicates whether the directory is a teamfolder or not
 
-Valida values for ShareApi.GetShare:
+Valid values for [ShareApi.GetShare]:
   - count           - int       - the number of successfully completed downloads
   - created         - int       - UNIX timestamp
   - file_type       - string    - 'dir'
@@ -196,7 +196,7 @@ The size of a directory in a snapshot is sorted as 0 and not reported.
 With the value "none" the output is unsorted.
 
 Can be used in the following methods:
-  - DirApi.GetDir
+  - [DirApi.GetDir]
 */
 func (p *Parameters) SetSortBy(sortBy string) *Parameters {
 	p.Set("sort", sortBy)
@@ -209,7 +209,7 @@ SetSortLang - adds "sort_lang" parameter to the request - Determines the locale 
 Currently allowed values are `de_DE`, `en_US` and `sv_SE`.
 
 Can be used int the following methods:
-  - DirApi.GetDir
+  - [DirApi.GetDir]
 */
 func (p *Parameters) SetSortLang(lang string) *Parameters {
 	p.Set("sort_lang", lang)
@@ -224,7 +224,7 @@ Valid values are:
   - "autoname"  - find another name if the destination already exists
 
 Can be used in the following methods:
-  - FileApi.UploadFile
+  - [FileApi.UploadFile]
 */
 func (p *Parameters) SetOnExist(onExists string) *Parameters {
 	p.Set("on_exist", onExists)
@@ -236,8 +236,8 @@ SetMTime - adds "mtime" parameter to the request - the modification time (mtime)
 to be set after the operation.
 
 Can be used in the following methods:
-  - DirApi.CreateDir
-  - FileApi.UploadFile
+  - [DirApi.CreateDir]
+  - [FileApi.UploadFile]
 */
 func (p *Parameters) SetMTime(t time.Time) *Parameters {
 	timeStr := fmt.Sprint(t.Unix())
@@ -250,10 +250,10 @@ SetParentMTime - adds "parent_mtime" parameter to the query - the modification t
 target's parent folder to be set after the operation.
 
 Can be used in the following methods:
-  - DirApi.CreateDir
-  - DirApi.DeleteDir
-  - FileApi.DeleteFile
-  - FileApi.UploadFile
+  - [DirApi.CreateDir]
+  - [DirApi.DeleteDir]
+  - [FileApi.DeleteFile]
+  - [FileApi.UploadFile]
 */
 func (p *Parameters) SetParentMTime(t time.Time) *Parameters {
 	timeStr := fmt.Sprint(t.Unix())
@@ -266,7 +266,7 @@ SetRecursive - adds "recursive" parameter to the request - if `true`, the call w
 and their contents recursively without throwing a 409 Conflict error.
 
 Can be used in the following methods:
-  - DirApi.DeleteDir
+  - [DirApi.DeleteDir]
 */
 func (p *Parameters) SetRecursive(recursive bool) *Parameters {
 	p.Set("on_exist", fmt.Sprint(recursive))
@@ -288,7 +288,7 @@ Note: this is always a parent directory and must not contain the intended filena
 Use the SetName method to specify the file name.
 
 Can be used in the following methods:
-  - FileApi.UploadFile
+  - [FileApi.UploadFile]
 */
 func (p *Parameters) SetDir(dir string) *Parameters {
 	p.Set("dir", dir)
@@ -304,7 +304,7 @@ So after this operation, the dir_id may no longer be valid.
 However, the current value will be part of the returned information (as parent_id) after a successful request.
 
 Can be used in the following methods:
-  - FileApi.UploadFile
+  - [FileApi.UploadFile]
 */
 func (p *Parameters) SetDirId(id string) *Parameters {
 	p.Set("dir_id", id)
@@ -318,7 +318,7 @@ The name parameter is mandatory for binary uploads. It is forbidden for multipar
 to be specified as "filename" parameter within the content-disposition header.
 
 Can be used in the following methods:
-  - FileApi.UploadFile
+  - [FileApi.UploadFile]
 */
 func (p *Parameters) SetName(name string) *Parameters {
 	p.Set("name", name)
@@ -333,7 +333,7 @@ Use this method to simplify settings upload path with a single string instead of
 "name separately.
 
 Can be used in the following methods:
-  - FileApi.UploadFile
+  - [FileApi.UploadFile]
 */
 func (p *Parameters) SetFilePath(path string) *Parameters {
 	elems := strings.Split(path, "/")
@@ -351,7 +351,7 @@ When not provided, the value will be set to unlimited, if the user's tariff supp
 value permissible.
 
 Can be used in the following methods:
-  - ShareApi.CreateShare
+  - [ShareApi.CreateShare]
 */
 func (p *Parameters) SetMaxCount(count int) *Parameters {
 	p.Set("maxcount", fmt.Sprint(count))
@@ -365,7 +365,7 @@ Consider this recommended, especially the closer the share is set to the root di
 This parameter must be omitted for encrypted shares which require salt, share_access_key, pw_sharekey.
 
 Can be used in the following methods:
-  - ShareApi.CreateShare
+  - [ShareApi.CreateShare]
 */
 func (p *Parameters) SetPassword(password string) *Parameters {
 	p.Set("password", password)
@@ -378,7 +378,7 @@ SetWritable - adds "writable" parameter to the request - This option can be set 
 Note: This includes deletion and modification of existing content.
 
 Can be used in the following methods:
-  - ShareApi.CreateShare
+  - [ShareApi.CreateShare]
 */
 func (p *Parameters) SetWritable(writable bool) *Parameters {
 	p.Set("writable", fmt.Sprint(writable))
@@ -391,7 +391,7 @@ SetTTL - adds "ttl" parameter to the request - share expiry.
 A positive number defining seconds from now. Not specifying a value sets ttl to the tariff maximum.
 
 Can be used in the following methods:
-  - ShareApi.CreateShare
+  - [ShareApi.CreateShare]
 */
 func (p *Parameters) SetTTL(ttl uint) *Parameters {
 	p.Set("ttl", fmt.Sprint(ttl))
@@ -408,7 +408,7 @@ authentication that only requires knowledge of the share_access_key.
 Note: this attribute cannot be removed from a share.
 
 Can be used in the following methods:
-  - ShareApi.CreateShare
+  - [ShareApi.CreateShare]
 */
 func (p *Parameters) SetSalt(salt string) *Parameters {
 	p.Set("salt", salt)
@@ -420,7 +420,7 @@ SetShareAccessKey - adds "share_access_key" parameter to the request - Authentic
 library for encrypted shares. Requires `password` to be absent and salt and `pw_sharekey` to be present.
 
 Can be used in the following methods:
-  - ShareApi.CreateShare
+  - [ShareApi.CreateShare]
 */
 func (p *Parameters) SetShareAccessKey(key string) *Parameters {
 	p.Set("share_access_key", key)
@@ -432,7 +432,7 @@ SetPwShareKey - adds "pw_sharekey" parameter to the request - Password protected
 library for encrypted shares. Requires `password` to be absent and `salt` and `share_access_key` to be present.
 
 Can be used in the following methods:
-  - ShareApi.CreateShare
+  - [ShareApi.CreateShare]
 */
 func (p *Parameters) SetPwShareKey(key string) *Parameters {
 	p.Set("pw_sharekey", key)
@@ -443,9 +443,37 @@ func (p *Parameters) SetPwShareKey(key string) *Parameters {
 SetId - adds "id" parameter to the request - a share id as returned by ShareApi.GetShare or ShareApi.CreateShare.
 
 Can be used in the following methods:
-  - ShareApi.CreateShare
+  - [ShareApi.CreateShare]
 */
 func (p *Parameters) SetId(id string) *Parameters {
 	p.Set("id", id)
+	return p
+}
+
+/*
+SetRecipient - adds "recipient" parameter to the request - A RFC822-compliant, UTF-8 encoded e-mail address.
+
+The parameter can be specified multiple times to send an invitation to more than one recipient at once.
+
+Note: If the address is preceded by a string (e.g. "Bob Test" <bob@example.com>), the specified string is used as
+salutation in the generated mail without modification. It is recommended to specify names as "Firstname Lastname"
+instead of "Lastname, Firstname".
+
+Can be used in the following methods:
+  - [ShareApi.Invite]
+*/
+func (p *Parameters) SetRecipient(recip string) *Parameters {
+	p.Set("recipient", recip)
+	return p
+}
+
+/*
+SetMsg - adds "msg" parameter to the request - A UTF-8 encoded message text that will be included in the e-mail.
+
+Can be used in the following methods:
+  - [ShareApi.Invite]
+*/
+func (p *Parameters) SetMsg(msg string) *Parameters {
+	p.Set("msg", msg)
 	return p
 }

--- a/share.go
+++ b/share.go
@@ -280,7 +280,7 @@ func (s ShareApi) Invite(ctx context.Context, params url.Values) (*HiDriveShareI
 	}
 
 	obj := &HiDriveShareInviteResponse{}
-	if err := obj.UnmarshalJSON(body); err != nil {
+	if err := json.Unmarshal(body, obj); err != nil {
 		return nil, err
 	}
 

--- a/share.go
+++ b/share.go
@@ -57,7 +57,7 @@ func (s ShareApi) GetShare(ctx context.Context, params url.Values) ([]*HiDriveSh
 		}
 	}
 
-	if err := s.checkHTTPStatus(http.StatusOK, res); err != nil {
+	if err := s.checkHTTPStatusError([]int{http.StatusOK}, res); err != nil {
 		return nil, err
 	}
 
@@ -120,7 +120,7 @@ func (s ShareApi) CreateShare(ctx context.Context, params url.Values) (*HiDriveS
 		}
 	}
 
-	if err := s.checkHTTPStatus(http.StatusCreated, res); err != nil {
+	if err := s.checkHTTPStatusError([]int{http.StatusCreated}, res); err != nil {
 		return nil, err
 	}
 
@@ -164,7 +164,7 @@ func (s ShareApi) DeleteShare(ctx context.Context, params url.Values) error {
 		}
 	}
 
-	if err := s.checkHTTPStatus(http.StatusNoContent, res); err != nil {
+	if err := s.checkHTTPStatusError([]int{http.StatusNoContent}, res); err != nil {
 		return err
 	}
 
@@ -208,7 +208,7 @@ func (s ShareApi) UpdateShare(ctx context.Context, params url.Values) (*HiDriveS
 		}
 	}
 
-	if err := s.checkHTTPStatus(http.StatusOK, res); err != nil {
+	if err := s.checkHTTPStatusError([]int{http.StatusOK}, res); err != nil {
 		return nil, err
 	}
 
@@ -220,6 +220,66 @@ func (s ShareApi) UpdateShare(ctx context.Context, params url.Values) (*HiDriveS
 	}
 
 	obj := &HiDriveShareObject{}
+	if err := obj.UnmarshalJSON(body); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+/*
+Invite - Invite other people to a share via e-mail.
+
+Status codes:
+  - 200 - OK
+  - 207 - Multi-Status (body contains multiple status messages)
+  - 400 - Bad Request (e.g. invalid parameter)
+  - 401 - Unauthorized (no authentication)
+  - 403 - Forbidden (wrong password)
+  - 404 - Not Found (e.g. ID not existing)
+  - 410 - Gone
+  - 500 - Internal Error
+
+Supported parameters:
+  - id ([Parameters.SetId])
+  - path ([Parameters.SetPath])
+  - pid ([Parameters.SetPid])
+  - fields ([Parameters.SetFields])
+
+Returns [HiDriveShareInviteResponse] object.
+
+The returned object contains the keys `done` and `failed`. Each of these keys holds an array of objects describing
+successfully and unsuccessfully processed recipients. Each object holds at least the key `to`, which stores the
+recipient's e-mail address. Failure-objects contain an additional key `msg` which describes the encountered error.
+If all processed recipients share the same status code, the code will be returned as HTTP status code.
+Partial success or differing status codes are indicated by setting the HTTP status code to "207 Multi-Status".
+Failure- and done-objects will then contain the individual status of each processed recipient.
+*/
+func (s ShareApi) Invite(ctx context.Context, params url.Values) (*HiDriveShareInviteResponse, error) {
+	var (
+		res  *http.Response
+		body []byte
+	)
+
+	{
+		var err error
+		if res, err = s.doPOST(ctx, "share/invite", params, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := s.checkHTTPStatusError([]int{http.StatusOK, http.StatusMultiStatus}, res); err != nil {
+		return nil, err
+	}
+
+	{
+		var err error
+		if body, err = io.ReadAll(res.Body); err != nil {
+			return nil, err
+		}
+	}
+
+	obj := &HiDriveShareInviteResponse{}
 	if err := obj.UnmarshalJSON(body); err != nil {
 		return nil, err
 	}

--- a/share_test.go
+++ b/share_test.go
@@ -5,7 +5,10 @@ package go_hidrive
 
 import (
 	"context"
+	"fmt"
+	"github.com/google/uuid"
 	"net/url"
+	"os"
 	"testing"
 )
 
@@ -53,4 +56,81 @@ func TestShareApi_CreateShare(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestShareApi_Invite(t *testing.T) {
+	type fields struct {
+		Api Api
+	}
+	type args struct {
+		ctx    context.Context
+		params url.Values
+	}
+
+	client, err := createTestHTTPClient()
+	if err != nil {
+		t.Errorf("error setting up HTTP client: %s", err.Error())
+		return
+	}
+	shareApi := NewShareApi(client, StratoHiDriveAPIV21)
+	dirAPi := NewDirApi(client, StratoHiDriveAPIV21)
+	ctx := context.Background()
+
+	testFilePath := fmt.Sprintf("/public/test_dir_for_sharing_%s", uuid.New().String())
+	var dirObj *HiDriveObject
+	var shareObj *HiDriveShareObject
+
+	{
+		var err error
+		if dirObj, err = dirAPi.CreateDir(ctx, NewParameters().SetPath(testFilePath).Values); err != nil {
+			t.Errorf("CreateDir() error = %v", err)
+			return
+		}
+	}
+
+	{
+		var err error
+		if shareObj, err = shareApi.CreateShare(ctx, NewParameters().SetPath(dirObj.Path).SetPassword("test@123!").Values); err != nil {
+			t.Errorf("CreateShare() error = %v", err)
+			return
+		}
+	}
+	fmt.Println(shareObj.ID)
+
+	{
+		var err error
+		recip, ok := os.LookupEnv("STRATO_INVITE_EMAIL")
+		if !ok || recip == "" {
+			t.Error("Environment variable STRATO_INVITE_EMAIL is not properly set", err)
+		}
+		if _, err = shareApi.Invite(ctx,
+			NewParameters().SetId(shareObj.ID).SetRecipient(recip).SetMsg("Test invitation from good people").Values,
+		); err != nil {
+			t.Errorf("Invite() error = %v", err)
+		}
+	}
+
+	{
+		var err error
+		if err = dirAPi.DeleteDir(ctx, NewParameters().SetPath(testFilePath).Values); err != nil {
+			t.Errorf("DeleteDir() error = %v", err)
+			return
+		}
+	}
+
+	//for _, tt := range tests {
+	//	t.Run(tt.name, func(t *testing.T) {
+	//		s := ShareApi{
+	//			Api: tt.fields.Api,
+	//		}
+	//		_, err := s.Invite(tt.args.ctx, tt.args.params)
+	//		if (err != nil) != tt.wantErr {
+	//			t.Errorf("Invite() error = %v, wantErr %v", err, tt.wantErr)
+	//			return
+	//		}
+	//		//if !reflect.DeepEqual(got, tt.want) {
+	//		//	t.Errorf("Invite() got = %v, want %v", got, tt.want)
+	//		//}
+	//	})
+	//}
 }

--- a/types.go
+++ b/types.go
@@ -124,7 +124,3 @@ type HiDriveShareInviteResponse struct {
 	Done   []HiDriveShareInviteStatus `json:"done"`
 	Failed []HiDriveShareInviteStatus `json:"failed"`
 }
-
-func (s *HiDriveShareInviteResponse) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, s)
-}

--- a/types.go
+++ b/types.go
@@ -113,3 +113,18 @@ func (s *HiDriveShareObject) UnmarshalJSON(b []byte) error {
 	*s = HiDriveShareObject(defaultObject)
 	return nil
 }
+
+type HiDriveShareInviteStatus struct {
+	To      string `json:"to"`
+	Code    int    `json:"code"`
+	Message string `json:"msg"`
+}
+
+type HiDriveShareInviteResponse struct {
+	Done   []HiDriveShareInviteStatus `json:"done"`
+	Failed []HiDriveShareInviteStatus `json:"failed"`
+}
+
+func (s *HiDriveShareInviteResponse) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, s)
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,11 @@
+package go_hidrive
+
+func isItemInSlice[T comparable](slice []T, item T) bool {
+	for _, v := range slice {
+		if v == item {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
* Extended `ShareApi` with `Invite` method
* Internal function `checkHTTPStatus` renamed to `checkHTTPStatusError` and now supports multiple successful codes in input parameters
* Introduced new types `HiDriveShareInviteResponse` and `HiDriveShareInviteStatus to support new `ShareApi.Invite` method
* Added integration test `TestShareApi_Invite`
* Added new methods to `Parameters` object: `SetRecipient`,`SetMsg`
* Minor refactoring