### PR TITLE
v0.3.0 (BREAKING CHANGES)

### DIFF
--- a/dir_test.go
+++ b/dir_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 )
 
-func TestDirApi_GetDir(t *testing.T) {
+func TestDir_Get(t *testing.T) {
 	type fields struct {
-		Api DirApi
+		Api Dir
 	}
 	type args struct {
 		params url.Values
@@ -23,14 +23,14 @@ func TestDirApi_GetDir(t *testing.T) {
 		t.Errorf("error setting up HTTP client: %s", err.Error())
 		return
 	}
-	dirApi := NewDirApi(client, StratoHiDriveAPIV21)
+	dirApi := NewDir(client, StratoHiDriveAPIV21)
 	ctx := context.Background()
 
 	tests := []struct {
 		name    string
 		fields  fields
 		args    args
-		want    *HiDriveObject
+		want    *Object
 		wantErr bool
 	}{
 		{
@@ -65,20 +65,20 @@ func TestDirApi_GetDir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := dirApi.GetDir(ctx, tt.args.params)
+			_, err := dirApi.Get(ctx, tt.args.params)
 			ddParams := NewParameters().SetPath(tt.args.params.Get("path")).SetRecursive(false).Values
-			_ = dirApi.DeleteDir(ctx, ddParams)
+			_ = dirApi.Delete(ctx, ddParams)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetDir() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})
 	}
 }
 
-func TestDirApi_DeleteDir(t *testing.T) {
+func TestDir_Delete(t *testing.T) {
 	type fields struct {
-		Api DirApi
+		Api Dir
 	}
 	type args struct {
 		params url.Values
@@ -89,7 +89,7 @@ func TestDirApi_DeleteDir(t *testing.T) {
 		t.Errorf("error setting up HTTP client: %s", err.Error())
 		return
 	}
-	dirApi := NewDirApi(client, StratoHiDriveAPIV21)
+	dirApi := NewDir(client, StratoHiDriveAPIV21)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -109,16 +109,16 @@ func TestDirApi_DeleteDir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := dirApi.DeleteDir(ctx, tt.args.params); (err != nil) != tt.wantErr {
-				t.Errorf("DeleteDir() error = %v, wantErr %v", err, tt.wantErr)
+			if err := dirApi.Delete(ctx, tt.args.params); (err != nil) != tt.wantErr {
+				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
 }
 
-func TestDirApi_CreateDir(t *testing.T) {
+func TestDir_Create(t *testing.T) {
 	type fields struct {
-		Api DirApi
+		Api Dir
 	}
 	type args struct {
 		params url.Values
@@ -129,14 +129,14 @@ func TestDirApi_CreateDir(t *testing.T) {
 		t.Errorf("error setting up HTTP client: %s", err.Error())
 		return
 	}
-	dirApi := NewDirApi(client, StratoHiDriveAPIV21)
+	dirApi := NewDir(client, StratoHiDriveAPIV21)
 	ctx := context.Background()
 
 	tests := []struct {
 		name    string
 		fields  fields
 		args    args
-		want    *HiDriveObject
+		want    *Object
 		wantErr bool
 	}{
 		{
@@ -158,18 +158,18 @@ func TestDirApi_CreateDir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := dirApi.CreateDir(ctx, tt.args.params)
+			_, err := dirApi.Create(ctx, tt.args.params)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("CreateDir() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})
 	}
 }
 
-func TestDirApi_CreatePath(t *testing.T) {
+func TestDir_CreatePath(t *testing.T) {
 	type fields struct {
-		Api DirApi
+		Api Dir
 	}
 	type args struct {
 		params url.Values
@@ -180,14 +180,14 @@ func TestDirApi_CreatePath(t *testing.T) {
 		t.Errorf("error setting up HTTP client: %s", err.Error())
 		return
 	}
-	dirApi := NewDirApi(client, StratoHiDriveAPIV21)
+	dirApi := NewDir(client, StratoHiDriveAPIV21)
 	ctx := context.Background()
 
 	tests := []struct {
 		name    string
 		fields  fields
 		args    args
-		want    *HiDriveObject
+		want    *Object
 		wantErr bool
 	}{
 		{

--- a/errors.go
+++ b/errors.go
@@ -7,19 +7,19 @@ import (
 )
 
 /*
-HiDriveError - represents HiDrive JSON-encoded errors.
+Error - represents HiDrive JSON-encoded errors.
 
 Every time an API call receives non-OK code HiDrive also provides explanation in the response body.
 This response is converted into this type and returned as error on each method.
 */
-type HiDriveError struct {
+type Error struct {
 	Code    json.Number `json:"code"`
 	Message string      `json:"msg"`
 }
 
-// HiDriveError returns a string for the error and satisfies the error interface.
-func (e *HiDriveError) Error() string {
-	out := fmt.Sprintf("HiDriveError %q", e.Code.String())
+// Error returns a string for the error and satisfies the error interface.
+func (e *Error) Error() string {
+	out := fmt.Sprintf("Error %q", e.Code.String())
 	if e.Message != "" {
 		out += ": " + e.Message
 	}

--- a/file_test.go
+++ b/file_test.go
@@ -26,7 +26,7 @@ func (c *ClosingBuffer) Close() (err error) {
 
 func TestFileApi_UploadFile(t *testing.T) {
 	type fields struct {
-		Api FileApi
+		Api File
 	}
 	type args struct {
 		params   url.Values
@@ -38,14 +38,14 @@ func TestFileApi_UploadFile(t *testing.T) {
 		t.Errorf("error setting up HTTP client: %s", err.Error())
 		return
 	}
-	fileApi := NewFileApi(client, StratoHiDriveAPIV21)
+	fileApi := NewFile(client, StratoHiDriveAPIV21)
 	ctx := context.Background()
 
 	tests := []struct {
 		name    string
 		fields  fields
 		args    args
-		want    *HiDriveObject
+		want    *Object
 		wantErr bool
 	}{
 		{
@@ -70,9 +70,9 @@ func TestFileApi_UploadFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := fileApi.UploadFile(ctx, tt.args.params, tt.args.fileBody)
+			_, err := fileApi.Upload(ctx, tt.args.params, tt.args.fileBody)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("UploadFile() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Upload() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})
@@ -81,7 +81,7 @@ func TestFileApi_UploadFile(t *testing.T) {
 
 func TestFileApi_DeleteFile(t *testing.T) {
 	type fields struct {
-		Api FileApi
+		Api File
 	}
 	type args struct {
 		params url.Values
@@ -92,7 +92,7 @@ func TestFileApi_DeleteFile(t *testing.T) {
 		t.Errorf("error setting up HTTP client: %s", err.Error())
 		return
 	}
-	fileApi := NewFileApi(client, StratoHiDriveAPIV21)
+	fileApi := NewFile(client, StratoHiDriveAPIV21)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -124,7 +124,7 @@ func TestFileApi_DeleteFile(t *testing.T) {
 					}
 					path := fmt.Sprintf("/public/%s", uuid.New().String())
 					prm := NewParameters().SetFilePath(path).Values
-					if _, err := fileApi.UploadFile(ctx, prm, buf); err != nil {
+					if _, err := fileApi.Upload(ctx, prm, buf); err != nil {
 						return ""
 					}
 
@@ -137,8 +137,8 @@ func TestFileApi_DeleteFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := fileApi.DeleteFile(ctx, tt.args.params); (err != nil) != tt.wantErr {
-				t.Errorf("DeleteFile() error = %v, wantErr %v", err, tt.wantErr)
+			if err := fileApi.Delete(ctx, tt.args.params); (err != nil) != tt.wantErr {
+				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/meta.go
+++ b/meta.go
@@ -1,0 +1,122 @@
+package go_hidrive
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+/*
+Meta - structure represents a set of methods for interacting with HiDrive `/meta` API endpoint.
+*/
+type Meta struct {
+	Api
+}
+
+/*
+NewMeta - create new instance of Meta.
+
+Accepts http.Client and API endpoint as input parameters.
+If `endpoint` is empty string, then default `StratoHiDriveAPIV21` value is used.
+*/
+func NewMeta(client *http.Client, endpoint string) Meta {
+	api := NewApi(client, endpoint)
+	return Meta{api}
+}
+
+/*
+Get - get metadata of a storage object (dir, file or symlink).
+At least one of the parameters path and pid is mandatory.
+If both are given, pid must address a directory and the value of path is a relative path from that directory.
+
+To get data from a snapshot, the name of the snapshot must be provided in the snapshot parameter. The name must be UTF-8 encoded.
+
+Status codes:
+  - 200 - OK
+  - 400 - Bad Request (e.g. invalid parameter)
+  - 401 - Unauthorized (no authentication)
+  - 403 - Forbidden (wrong password)
+  - 404 - Not Found (e.g. ID not existing)
+  - 500 - Internal Error
+
+Supported parameters:
+  - path ([Parameters.SetPath])
+  - pid ([Parameters.SetPid])
+  - fields ([Parameters.SetFields])
+*/
+func (m Meta) Get(ctx context.Context, params url.Values) (*Object, error) {
+	var (
+		res  *http.Response
+		body []byte
+	)
+
+	{
+		var err error
+		if res, err = m.doGET(ctx, "meta", params, []int{http.StatusOK}); err != nil {
+			return nil, err
+		}
+	}
+
+	{
+		var err error
+		if body, err = io.ReadAll(res.Body); err != nil {
+			return nil, err
+		}
+	}
+
+	obj := &Object{}
+	if err := json.Unmarshal(body, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+/*
+Update - modify metadata of a file or directory.
+
+At the moment `mtime` is the only attribute that can be changed.
+An attempt to modify metadata of a symlink causes 404 Not Found.
+
+Status codes:
+  - 200 - OK
+  - 400 - Bad Request (e.g. invalid parameter)
+  - 401 - Unauthorized (no authentication)
+  - 403 - Forbidden (wrong password)
+  - 404 - Not Found (e.g. ID not existing)
+  - 500 - Internal Error
+
+Supported parameters:
+  - path ([Parameters.SetPath])
+  - pid ([Parameters.SetPid])
+  - mtime ([Parameters.SetMTime])
+*/
+func (m Meta) Update(ctx context.Context, params url.Values) (*Object, error) {
+	var (
+		res  *http.Response
+		body []byte
+	)
+
+	{
+		var err error
+		if res, err = m.doPATCH(ctx, "meta", params, []int{http.StatusOK, http.StatusNoContent}, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	{
+		var err error
+		if body, err = io.ReadAll(res.Body); err != nil {
+			return nil, err
+		}
+	}
+
+	obj := &Object{}
+	if err := json.Unmarshal(body, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}

--- a/meta_test.go
+++ b/meta_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+// +build integration
+
+package go_hidrive
+
+import (
+	"context"
+	"net/url"
+	"testing"
+)
+
+func TestMeta_Get(t *testing.T) {
+	type fields struct {
+		Api Meta
+	}
+	type args struct {
+		ctx    context.Context
+		params url.Values
+	}
+
+	client, err := createTestHTTPClient()
+	if err != nil {
+		t.Errorf("error setting up HTTP client: %s", err.Error())
+		return
+	}
+	metaApi := NewMeta(client, StratoHiDriveAPIV21)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *Object
+		wantErr bool
+	}{
+		{
+			name:    "Simple test for /public directory",
+			wantErr: false,
+			fields:  fields{Api: metaApi},
+			args: args{
+				ctx:    ctx,
+				params: NewParameters().SetPath("/public").SetFields([]string{"rshare"}).Values,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.fields.Api
+			_, err := m.Get(tt.args.ctx, tt.args.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/params.go
+++ b/params.go
@@ -19,13 +19,13 @@ func NewParameters() *Parameters {
 SetPath adds "path" parameter to the query - path to a filesystem object
 
 Can be used in the following methods:
-  - [DirApi.GetDir]
-  - [DirApi.CreateDir]
-  - [DirApi.DeleteDir]
-  - [FileApi.GetFile]
-  - [FileApi.DeleteFile]
-  - [ShareApi.GetShare]
-  - [ShareApi.CreateShare]
+  - [Dir.Get]
+  - [Dir.Create]
+  - [Dir.Delete]
+  - [File.Get]
+  - [File.Delete]
+  - [Share.Get]
+  - [Share.Create]
 */
 func (p *Parameters) SetPath(path string) *Parameters {
 	p.Set("path", path)
@@ -39,13 +39,13 @@ The public id is a path and encoding independent representation
 of a specific filesystem object. Also returned and referred to as id in data related responses.
 
 Can be used in the following methods:
-  - [DirApi.GetDir]
-  - [DirApi.CreateDir]
-  - [DirApi.DeleteDir]
-  - [FileApi.GetFile]
-  - [FileApi.DeleteFile]
-  - [ShareApi.GetShare]
-  - [ShareApi.CreateShare]
+  - [Dir.Get]
+  - [Dir.Create]
+  - [Dir.Delete]
+  - [File.Get]
+  - [File.Delete]
+  - [Share.Get]
+  - [Share.Create]
 */
 func (p *Parameters) SetPid(pid string) *Parameters {
 	p.Set("pid", pid)
@@ -63,7 +63,7 @@ Valid values are:
   - symlink - include symlinks          (not in combination with none or all)
 
 Can be used in the following methods:
-  - [DirApi.GetDir]
+  - [Dir.Get]
 */
 func (p *Parameters) SetMembers(members []string) *Parameters {
 	memStr := strings.Join(members, ",")
@@ -82,7 +82,7 @@ To get all directory entries it is always recommended to check the nmembers fiel
 A value of none or 0 for <limit> signifies to return as many entries as is feasible. This also works when combined with an offset.
 
 Can be used in the following methods:
-  - [DirApi.GetDir]
+  - [Dir.Get]
 */
 func (p *Parameters) SetLimit(limit uint, offset uint) *Parameters {
 	p.Set("limit", fmt.Sprintf("%d,%d", offset, limit))
@@ -96,10 +96,10 @@ The performance of the call might be influenced by the amount of information req
 Therefore, it is recommended to use a "need to know" approach instead of "get all".
 
 Can be used in the following methods:
-  - DirApi.GetFile
-  - ShareAPi.GetShare
+  - [Dir.Get]
+  - [Share.Get]
 
-Valid values for [DirApi.GetDir]:
+Valid values for [Dir.Get]:
   - category                - string    - object category (audio, image, etc.)
   - chash (*)               - string    - recursive hashvalue for the directory
   - ctime                   - timestamp - ctime of the object
@@ -150,7 +150,7 @@ Valid values for [DirApi.GetDir]:
   - shareable               - bool      - share-permission for the directory
   - teamfolder              - bool      - indicates whether the directory is a teamfolder or not
 
-Valid values for [ShareApi.GetShare]:
+Valid values for [Share.Get]:
   - count           - int       - the number of successfully completed downloads
   - created         - int       - UNIX timestamp
   - file_type       - string    - 'dir'
@@ -196,7 +196,7 @@ The size of a directory in a snapshot is sorted as 0 and not reported.
 With the value "none" the output is unsorted.
 
 Can be used in the following methods:
-  - [DirApi.GetDir]
+  - [Dir.Get]
 */
 func (p *Parameters) SetSortBy(sortBy string) *Parameters {
 	p.Set("sort", sortBy)
@@ -209,7 +209,7 @@ SetSortLang - adds "sort_lang" parameter to the request - Determines the locale 
 Currently allowed values are `de_DE`, `en_US` and `sv_SE`.
 
 Can be used int the following methods:
-  - [DirApi.GetDir]
+  - [Dir.Get]
 */
 func (p *Parameters) SetSortLang(lang string) *Parameters {
 	p.Set("sort_lang", lang)
@@ -224,7 +224,7 @@ Valid values are:
   - "autoname"  - find another name if the destination already exists
 
 Can be used in the following methods:
-  - [FileApi.UploadFile]
+  - [File.Upload]
 */
 func (p *Parameters) SetOnExist(onExists string) *Parameters {
 	p.Set("on_exist", onExists)
@@ -236,8 +236,8 @@ SetMTime - adds "mtime" parameter to the request - the modification time (mtime)
 to be set after the operation.
 
 Can be used in the following methods:
-  - [DirApi.CreateDir]
-  - [FileApi.UploadFile]
+  - [Dir.Create]
+  - [File.Upload]
 */
 func (p *Parameters) SetMTime(t time.Time) *Parameters {
 	timeStr := fmt.Sprint(t.Unix())
@@ -250,10 +250,10 @@ SetParentMTime - adds "parent_mtime" parameter to the query - the modification t
 target's parent folder to be set after the operation.
 
 Can be used in the following methods:
-  - [DirApi.CreateDir]
-  - [DirApi.DeleteDir]
-  - [FileApi.DeleteFile]
-  - [FileApi.UploadFile]
+  - [Dir.Create]
+  - [Dir.Delete]
+  - [File.Delete]
+  - [File.Upload]
 */
 func (p *Parameters) SetParentMTime(t time.Time) *Parameters {
 	timeStr := fmt.Sprint(t.Unix())
@@ -266,7 +266,7 @@ SetRecursive - adds "recursive" parameter to the request - if `true`, the call w
 and their contents recursively without throwing a 409 Conflict error.
 
 Can be used in the following methods:
-  - [DirApi.DeleteDir]
+  - [Dir.Delete]
 */
 func (p *Parameters) SetRecursive(recursive bool) *Parameters {
 	p.Set("on_exist", fmt.Sprint(recursive))
@@ -288,7 +288,7 @@ Note: this is always a parent directory and must not contain the intended filena
 Use the SetName method to specify the file name.
 
 Can be used in the following methods:
-  - [FileApi.UploadFile]
+  - [File.Upload]
 */
 func (p *Parameters) SetDir(dir string) *Parameters {
 	p.Set("dir", dir)
@@ -304,7 +304,7 @@ So after this operation, the dir_id may no longer be valid.
 However, the current value will be part of the returned information (as parent_id) after a successful request.
 
 Can be used in the following methods:
-  - [FileApi.UploadFile]
+  - [File.Upload]
 */
 func (p *Parameters) SetDirId(id string) *Parameters {
 	p.Set("dir_id", id)
@@ -318,7 +318,7 @@ The name parameter is mandatory for binary uploads. It is forbidden for multipar
 to be specified as "filename" parameter within the content-disposition header.
 
 Can be used in the following methods:
-  - [FileApi.UploadFile]
+  - [File.Upload]
 */
 func (p *Parameters) SetName(name string) *Parameters {
 	p.Set("name", name)
@@ -333,7 +333,7 @@ Use this method to simplify settings upload path with a single string instead of
 "name separately.
 
 Can be used in the following methods:
-  - [FileApi.UploadFile]
+  - [File.Upload]
 */
 func (p *Parameters) SetFilePath(path string) *Parameters {
 	elems := strings.Split(path, "/")
@@ -351,7 +351,7 @@ When not provided, the value will be set to unlimited, if the user's tariff supp
 value permissible.
 
 Can be used in the following methods:
-  - [ShareApi.CreateShare]
+  - [Share.Create]
 */
 func (p *Parameters) SetMaxCount(count int) *Parameters {
 	p.Set("maxcount", fmt.Sprint(count))
@@ -365,7 +365,7 @@ Consider this recommended, especially the closer the share is set to the root di
 This parameter must be omitted for encrypted shares which require salt, share_access_key, pw_sharekey.
 
 Can be used in the following methods:
-  - [ShareApi.CreateShare]
+  - [Share.Create]
 */
 func (p *Parameters) SetPassword(password string) *Parameters {
 	p.Set("password", password)
@@ -378,7 +378,7 @@ SetWritable - adds "writable" parameter to the request - This option can be set 
 Note: This includes deletion and modification of existing content.
 
 Can be used in the following methods:
-  - [ShareApi.CreateShare]
+  - [Share.Create]
 */
 func (p *Parameters) SetWritable(writable bool) *Parameters {
 	p.Set("writable", fmt.Sprint(writable))
@@ -391,7 +391,7 @@ SetTTL - adds "ttl" parameter to the request - share expiry.
 A positive number defining seconds from now. Not specifying a value sets ttl to the tariff maximum.
 
 Can be used in the following methods:
-  - [ShareApi.CreateShare]
+  - [Share.Create]
 */
 func (p *Parameters) SetTTL(ttl uint) *Parameters {
 	p.Set("ttl", fmt.Sprint(ttl))
@@ -408,7 +408,7 @@ authentication that only requires knowledge of the share_access_key.
 Note: this attribute cannot be removed from a share.
 
 Can be used in the following methods:
-  - [ShareApi.CreateShare]
+  - [Share.Create]
 */
 func (p *Parameters) SetSalt(salt string) *Parameters {
 	p.Set("salt", salt)
@@ -420,7 +420,7 @@ SetShareAccessKey - adds "share_access_key" parameter to the request - Authentic
 library for encrypted shares. Requires `password` to be absent and salt and `pw_sharekey` to be present.
 
 Can be used in the following methods:
-  - [ShareApi.CreateShare]
+  - [Share.Create]
 */
 func (p *Parameters) SetShareAccessKey(key string) *Parameters {
 	p.Set("share_access_key", key)
@@ -432,7 +432,7 @@ SetPwShareKey - adds "pw_sharekey" parameter to the request - Password protected
 library for encrypted shares. Requires `password` to be absent and `salt` and `share_access_key` to be present.
 
 Can be used in the following methods:
-  - [ShareApi.CreateShare]
+  - [Share.Create]
 */
 func (p *Parameters) SetPwShareKey(key string) *Parameters {
 	p.Set("pw_sharekey", key)
@@ -440,10 +440,10 @@ func (p *Parameters) SetPwShareKey(key string) *Parameters {
 }
 
 /*
-SetId - adds "id" parameter to the request - a share id as returned by ShareApi.GetShare or ShareApi.CreateShare.
+SetId - adds "id" parameter to the request - a share id as returned by [Share.Get] or [Share.Create].
 
 Can be used in the following methods:
-  - [ShareApi.CreateShare]
+  - [Share.Create]
 */
 func (p *Parameters) SetId(id string) *Parameters {
 	p.Set("id", id)
@@ -460,7 +460,7 @@ salutation in the generated mail without modification. It is recommended to spec
 instead of "Lastname, Firstname".
 
 Can be used in the following methods:
-  - [ShareApi.Invite]
+  - [Share.Invite]
 */
 func (p *Parameters) SetRecipient(recip string) *Parameters {
 	p.Set("recipient", recip)
@@ -471,7 +471,7 @@ func (p *Parameters) SetRecipient(recip string) *Parameters {
 SetMsg - adds "msg" parameter to the request - A UTF-8 encoded message text that will be included in the e-mail.
 
 Can be used in the following methods:
-  - [ShareApi.Invite]
+  - [Share.Invite]
 */
 func (p *Parameters) SetMsg(msg string) *Parameters {
 	p.Set("msg", msg)

--- a/share.go
+++ b/share.go
@@ -9,25 +9,25 @@ import (
 )
 
 /*
-ShareApi - structure represents a set of methods for interacting with HiDrive `/share` API endpoint.
+Share - structure represents a set of methods for interacting with HiDrive `/share` API endpoint.
 */
-type ShareApi struct {
+type Share struct {
 	Api
 }
 
 /*
-NewShareApi - create new instance of ShareApi.
+NewShare - create new instance of Share.
 
 Accepts http.Client and API endpoint as input parameters.
 If `endpoint` is empty string, then default `StratoHiDriveAPIV21` value is used.
 */
-func NewShareApi(client *http.Client, endpoint string) ShareApi {
+func NewShare(client *http.Client, endpoint string) Share {
 	api := NewApi(client, endpoint)
-	return ShareApi{api}
+	return Share{api}
 }
 
 /*
-GetShare - Get information about either one (given "id", "path" or "pid" parameter) or every existing share created by the authenticated user.
+Get - Get information about either one (given "id", "path" or "pid" parameter) or every existing share created by the authenticated user.
 You may customize the result set by adding optional "fields" values.
 
 Status codes:
@@ -44,7 +44,7 @@ Supported parameters:
   - pid ([Parameters.SetPid])
   - fields ([Parameters.SetFields])
 */
-func (s ShareApi) GetShare(ctx context.Context, params url.Values) (*HiDriveShareObject, error) {
+func (s Share) Get(ctx context.Context, params url.Values) (*ShareObject, error) {
 	var (
 		res  *http.Response
 		body []byte
@@ -52,13 +52,9 @@ func (s ShareApi) GetShare(ctx context.Context, params url.Values) (*HiDriveShar
 
 	{
 		var err error
-		if res, err = s.doGET(ctx, "share", params); err != nil {
+		if res, err = s.doGET(ctx, "share", params, []int{http.StatusOK}); err != nil {
 			return nil, err
 		}
-	}
-
-	if err := s.checkHTTPStatusError([]int{http.StatusOK}, res); err != nil {
-		return nil, err
 	}
 
 	{
@@ -68,7 +64,7 @@ func (s ShareApi) GetShare(ctx context.Context, params url.Values) (*HiDriveShar
 		}
 	}
 
-	obj := &HiDriveShareObject{}
+	obj := &ShareObject{}
 	if err := json.Unmarshal(body, &obj); err != nil {
 		return nil, err
 	}
@@ -77,7 +73,7 @@ func (s ShareApi) GetShare(ctx context.Context, params url.Values) (*HiDriveShar
 }
 
 /*
-CreateShare - create a new share for a given directory anywhere inside your accessible HiDrive.
+Create - create a new share for a given directory anywhere inside your accessible HiDrive.
 You may limit the validity of a share to a given amount of time and protect it with a password.
 
 Sharing a directory will allow anyone with knowledge of the specific (returned) share_id to access all data inside
@@ -107,7 +103,7 @@ Supported parameters:
   - share_access_key ([Parameters.SetShareAccessKey])
   - pw_sharekey ([Parameters.SetPwShareKey])
 */
-func (s ShareApi) CreateShare(ctx context.Context, params url.Values) (*HiDriveShareObject, error) {
+func (s Share) Create(ctx context.Context, params url.Values) (*ShareObject, error) {
 	var (
 		res  *http.Response
 		body []byte
@@ -115,13 +111,9 @@ func (s ShareApi) CreateShare(ctx context.Context, params url.Values) (*HiDriveS
 
 	{
 		var err error
-		if res, err = s.doPOST(ctx, "share", params, nil); err != nil {
+		if res, err = s.doPOST(ctx, "share", params, []int{http.StatusCreated}, nil); err != nil {
 			return nil, err
 		}
-	}
-
-	if err := s.checkHTTPStatusError([]int{http.StatusCreated}, res); err != nil {
-		return nil, err
 	}
 
 	{
@@ -131,7 +123,7 @@ func (s ShareApi) CreateShare(ctx context.Context, params url.Values) (*HiDriveS
 		}
 	}
 
-	obj := &HiDriveShareObject{}
+	obj := &ShareObject{}
 	if err := obj.UnmarshalJSON(body); err != nil {
 		return nil, err
 	}
@@ -141,7 +133,7 @@ func (s ShareApi) CreateShare(ctx context.Context, params url.Values) (*HiDriveS
 }
 
 /*
-DeleteShare - delete a given share, thus invalidating each existing share `access_token` immediately.
+Delete - delete a given share, thus invalidating each existing share `access_token` immediately.
 
 Status codes:
   - 204 - No Content
@@ -154,17 +146,8 @@ Status codes:
 Supported parameters:
   - id ([Parameters.SetId])
 */
-func (s ShareApi) DeleteShare(ctx context.Context, params url.Values) error {
-	var res *http.Response
-
-	{
-		var err error
-		if res, err = s.doDELETE(ctx, "share", params); err != nil {
-			return err
-		}
-	}
-
-	if err := s.checkHTTPStatusError([]int{http.StatusNoContent}, res); err != nil {
+func (s Share) Delete(ctx context.Context, params url.Values) error {
+	if _, err := s.doDELETE(ctx, "share", params, []int{http.StatusNoContent}); err != nil {
 		return err
 	}
 
@@ -172,7 +155,7 @@ func (s ShareApi) DeleteShare(ctx context.Context, params url.Values) error {
 }
 
 /*
-UpdateShare - update a given share. Change `ttl“, `maxcount` and add or remove a share password.
+Update - update a given share. Change `ttl“, `maxcount` and add or remove a share password.
 
 Note:  It is not possible to change the target directory of an existing share!
 Please create a new one, if you wish to share another directory.
@@ -195,7 +178,7 @@ Supported parameters:
   - share_access_key ([Parameters.SetShareAccessKey])
   - pw_sharekey ([Parameters.SetPwShareKey])
 */
-func (s ShareApi) UpdateShare(ctx context.Context, params url.Values) (*HiDriveShareObject, error) {
+func (s Share) Update(ctx context.Context, params url.Values) (*ShareObject, error) {
 	var (
 		res  *http.Response
 		body []byte
@@ -203,13 +186,9 @@ func (s ShareApi) UpdateShare(ctx context.Context, params url.Values) (*HiDriveS
 
 	{
 		var err error
-		if res, err = s.doPUT(ctx, "share", params, nil); err != nil {
+		if res, err = s.doPUT(ctx, "share", params, []int{http.StatusOK}, nil); err != nil {
 			return nil, err
 		}
-	}
-
-	if err := s.checkHTTPStatusError([]int{http.StatusOK}, res); err != nil {
-		return nil, err
 	}
 
 	{
@@ -219,7 +198,7 @@ func (s ShareApi) UpdateShare(ctx context.Context, params url.Values) (*HiDriveS
 		}
 	}
 
-	obj := &HiDriveShareObject{}
+	obj := &ShareObject{}
 	if err := obj.UnmarshalJSON(body); err != nil {
 		return nil, err
 	}
@@ -246,7 +225,7 @@ Supported parameters:
   - pid ([Parameters.SetPid])
   - fields ([Parameters.SetFields])
 
-Returns [HiDriveShareInviteResponse] object.
+Returns [ShareInviteResponse] object.
 
 The returned object contains the keys `done` and `failed`. Each of these keys holds an array of objects describing
 successfully and unsuccessfully processed recipients. Each object holds at least the key `to`, which stores the
@@ -255,7 +234,7 @@ If all processed recipients share the same status code, the code will be returne
 Partial success or differing status codes are indicated by setting the HTTP status code to "207 Multi-Status".
 Failure- and done-objects will then contain the individual status of each processed recipient.
 */
-func (s ShareApi) Invite(ctx context.Context, params url.Values) (*HiDriveShareInviteResponse, error) {
+func (s Share) Invite(ctx context.Context, params url.Values) (*ShareInviteResponse, error) {
 	var (
 		res  *http.Response
 		body []byte
@@ -263,13 +242,9 @@ func (s ShareApi) Invite(ctx context.Context, params url.Values) (*HiDriveShareI
 
 	{
 		var err error
-		if res, err = s.doPOST(ctx, "share/invite", params, nil); err != nil {
+		if res, err = s.doPOST(ctx, "share/invite", params, []int{http.StatusOK, http.StatusMultiStatus}, nil); err != nil {
 			return nil, err
 		}
-	}
-
-	if err := s.checkHTTPStatusError([]int{http.StatusOK, http.StatusMultiStatus}, res); err != nil {
-		return nil, err
 	}
 
 	{
@@ -279,215 +254,7 @@ func (s ShareApi) Invite(ctx context.Context, params url.Values) (*HiDriveShareI
 		}
 	}
 
-	obj := &HiDriveShareInviteResponse{}
-	if err := json.Unmarshal(body, obj); err != nil {
-		return nil, err
-	}
-
-	return obj, nil
-}
-
-/*
-CreateShareLink - create a new sharelink for a given file.
-
-Both, the "pid" and "path" parameters refer to the file, at least one of them is mandatory.
-If both are given, `pid` addresses a parent directory, and the value of `path` is a relative path to the actual file.
-
-Specific values might be limited by package-feature settings:
-Parameters `ttl` and `maxcount` are required, if the tariff defines a maximum limit for these values.
-The password protection feature is not available in all tariffs.
-
-Status codes:
-  - 201 - Created
-  - 400 - Bad Request (e.g. invalid parameter)
-  - 401 - Unauthorized (no authentication)
-  - 403 - Forbidden (wrong password)
-  - 404 - Not Found (e.g. ID not existing)
-  - 500 - Internal Error
-
-Supported parameters:
-  - maxcount ([Parameters.SetMaxCount])
-  - path ([Parameters.SetPath])
-  - pid ([Parameters.SetPid])
-  - password ([Parameters.SetPassword])
-  - ttl ([Parameters.SetTTL])
-  - type - always set by the method to value `file`
-*/
-func (s ShareApi) CreateShareLink(ctx context.Context, params url.Values) (*HiDriveShareObject, error) {
-	var (
-		res  *http.Response
-		body []byte
-	)
-
-	params.Set("type", "file")
-	{
-		var err error
-		if res, err = s.doPOST(ctx, "sharelink", params, nil); err != nil {
-			return nil, err
-		}
-	}
-
-	if err := s.checkHTTPStatusError([]int{http.StatusCreated}, res); err != nil {
-		return nil, err
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
-	}
-
-	obj := &HiDriveShareObject{}
-	if err := json.Unmarshal(body, obj); err != nil {
-		return nil, err
-	}
-
-	return obj, nil
-}
-
-/*
-GetShareLink - if no "id" parameter is given, a list of all sharelink objects of the user is returned.
-With a given "id" only the corresponding `sharelink` object is returned, if that exists.
-
-Status codes:
-  - 200 - OK
-  - 400 - Bad Request (e.g. invalid parameter)
-  - 401 - Unauthorized (password required)
-  - 403 - Forbidden (wrong password)
-  - 404 - Not Found (ID does not exist or given path is not shared).
-  - 500 - Internal Error
-
-Supported parameters:
-  - id ([Parameters.SetId])
-  - fields ([Parameters.SetFields])
-*/
-func (s ShareApi) GetShareLink(ctx context.Context, params url.Values) (*HiDriveShareObject, error) {
-	var (
-		res  *http.Response
-		body []byte
-	)
-
-	{
-		var err error
-		if res, err = s.doGET(ctx, "sharelink", params); err != nil {
-			return nil, err
-		}
-	}
-
-	if err := s.checkHTTPStatusError([]int{http.StatusOK}, res); err != nil {
-		return nil, err
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
-	}
-
-	obj := &HiDriveShareObject{}
-	if err := json.Unmarshal(body, obj); err != nil {
-		return nil, err
-	}
-
-	return obj, nil
-}
-
-/*
-UpdateShareLink - update values for a given `sharelink` (not available for all tariffs).
-
-Specific values might be limited due to package-feature settings:
-  - The password protection feature is not available in all tariffs.
-  - Parameters `ttl` and `maxcount` are required, if the tariff defines a maximum limit for these values.
-  - The new value for `maxcount` must be equal to greater than the current count and the difference
-    between the value of the current `maxcount` and the new `maxcount` may be limited, depending on the tariff.
-
-Status codes:
-  - 200 - OK
-  - 400 - Bad Request (e.g. invalid parameter)
-  - 401 - Unauthorized (no authentication)
-  - 403 - Forbidden (wrong password)
-  - 404 - Not Found (e.g. ID not existing)
-  - 500 - Internal Error
-
-Supported parameters:
-  - maxcount ([Parameters.SetMaxCount])
-  - id ([Parameters.SetId])
-  - password ([Parameters.SetPassword])
-  - ttl ([Parameters.SetTTL])
-*/
-func (s ShareApi) UpdateShareLink(ctx context.Context, params url.Values) (*HiDriveShareObject, error) {
-	var (
-		res  *http.Response
-		body []byte
-	)
-
-	{
-		var err error
-		if res, err = s.doPUT(ctx, "sharelink", params, nil); err != nil {
-			return nil, err
-		}
-	}
-
-	if err := s.checkHTTPStatusError([]int{http.StatusOK}, res); err != nil {
-		return nil, err
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
-	}
-
-	obj := &HiDriveShareObject{}
-	if err := json.Unmarshal(body, obj); err != nil {
-		return nil, err
-	}
-
-	return obj, nil
-}
-
-/*
-DeleteShareLink - remove `sharelink`.
-
-Status codes:
-  - 204 - No Content
-  - 400 - Bad Request (e.g. invalid parameter)
-  - 401 - Unauthorized
-  - 403 - Forbidden
-  - 404 - Not Found (e.g. ID not existing)
-  - 500 - Internal Error
-
-Supported parameters:
-  - id ([Parameters.SetId])
-*/
-func (s ShareApi) DeleteShareLink(ctx context.Context, params url.Values) (*HiDriveShareObject, error) {
-	var (
-		res  *http.Response
-		body []byte
-	)
-
-	{
-		var err error
-		if res, err = s.doDELETE(ctx, "sharelink", params); err != nil {
-			return nil, err
-		}
-	}
-
-	if err := s.checkHTTPStatusError([]int{http.StatusNoContent}, res); err != nil {
-		return nil, err
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
-	}
-
-	obj := &HiDriveShareObject{}
+	obj := &ShareInviteResponse{}
 	if err := json.Unmarshal(body, obj); err != nil {
 		return nil, err
 	}

--- a/share_test.go
+++ b/share_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 )
 
-func TestShareApi_CreateShare(t *testing.T) {
+func TestShare_Create(t *testing.T) {
 	type fields struct {
-		Api Api
+		Api Share
 	}
 	type args struct {
 		params url.Values
@@ -25,14 +25,14 @@ func TestShareApi_CreateShare(t *testing.T) {
 		t.Errorf("error setting up HTTP client: %s", err.Error())
 		return
 	}
-	shareApi := NewApi(client, StratoHiDriveAPIV21)
+	shareApi := NewShare(client, StratoHiDriveAPIV21)
 	ctx := context.Background()
 
 	tests := []struct {
 		name    string
 		fields  fields
 		args    args
-		want    *HiDriveShareObject
+		want    *ShareObject
 		wantErr bool
 	}{
 		{
@@ -46,19 +46,17 @@ func TestShareApi_CreateShare(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := ShareApi{
-				Api: tt.fields.Api,
-			}
-			_, err := s.CreateShare(ctx, tt.args.params)
+			s := tt.fields.Api
+			_, err := s.Create(ctx, tt.args.params)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("CreateShare() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})
 	}
 }
 
-func TestShareApi_Invite(t *testing.T) {
+func TestShare_Invite(t *testing.T) {
 	type fields struct {
 		Api Api
 	}
@@ -72,30 +70,29 @@ func TestShareApi_Invite(t *testing.T) {
 		t.Errorf("error setting up HTTP client: %s", err.Error())
 		return
 	}
-	shareApi := NewShareApi(client, StratoHiDriveAPIV21)
-	dirAPi := NewDirApi(client, StratoHiDriveAPIV21)
+	shareApi := NewShare(client, StratoHiDriveAPIV21)
+	dirAPi := NewDir(client, StratoHiDriveAPIV21)
 	ctx := context.Background()
 
 	testFilePath := fmt.Sprintf("/public/test_dir_for_sharing_%s", uuid.New().String())
-	var dirObj *HiDriveObject
-	var shareObj *HiDriveShareObject
+	var dirObj *Object
+	var shareObj *ShareObject
 
 	{
 		var err error
-		if dirObj, err = dirAPi.CreateDir(ctx, NewParameters().SetPath(testFilePath).Values); err != nil {
-			t.Errorf("CreateDir() error = %v", err)
+		if dirObj, err = dirAPi.Create(ctx, NewParameters().SetPath(testFilePath).Values); err != nil {
+			t.Errorf("Create() error = %v", err)
 			return
 		}
 	}
 
 	{
 		var err error
-		if shareObj, err = shareApi.CreateShare(ctx, NewParameters().SetPath(dirObj.Path).SetPassword("test@123!").Values); err != nil {
-			t.Errorf("CreateShare() error = %v", err)
+		if shareObj, err = shareApi.Create(ctx, NewParameters().SetPath(dirObj.Path).SetPassword("test@123!").Values); err != nil {
+			t.Errorf("Create() error = %v", err)
 			return
 		}
 	}
-	fmt.Println(shareObj.ID)
 
 	{
 		var err error
@@ -112,25 +109,9 @@ func TestShareApi_Invite(t *testing.T) {
 
 	{
 		var err error
-		if err = dirAPi.DeleteDir(ctx, NewParameters().SetPath(testFilePath).Values); err != nil {
-			t.Errorf("DeleteDir() error = %v", err)
+		if err = dirAPi.Delete(ctx, NewParameters().SetPath(testFilePath).Values); err != nil {
+			t.Errorf("Delete() error = %v", err)
 			return
 		}
 	}
-
-	//for _, tt := range tests {
-	//	t.Run(tt.name, func(t *testing.T) {
-	//		s := ShareApi{
-	//			Api: tt.fields.Api,
-	//		}
-	//		_, err := s.Invite(tt.args.ctx, tt.args.params)
-	//		if (err != nil) != tt.wantErr {
-	//			t.Errorf("Invite() error = %v, wantErr %v", err, tt.wantErr)
-	//			return
-	//		}
-	//		//if !reflect.DeepEqual(got, tt.want) {
-	//		//	t.Errorf("Invite() got = %v, want %v", got, tt.want)
-	//		//}
-	//	})
-	//}
 }

--- a/sharelink.go
+++ b/sharelink.go
@@ -1,0 +1,219 @@
+package go_hidrive
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+/*
+Sharelink - structure represents a set of methods for interacting with HiDrive `/sharelink` API endpoint.
+*/
+type Sharelink struct {
+	Api
+}
+
+/*
+NewSharelink - create new instance of Sharelink.
+
+Accepts http.Client and API endpoint as input parameters.
+If `endpoint` is empty string, then default `StratoHiDriveAPIV21` value is used.
+*/
+func NewSharelink(client *http.Client, endpoint string) Share {
+	api := NewApi(client, endpoint)
+	return Share{api}
+}
+
+/*
+CreateShareLink - create a new sharelink for a given file.
+
+Both, the "pid" and "path" parameters refer to the file, at least one of them is mandatory.
+If both are given, `pid` addresses a parent directory, and the value of `path` is a relative path to the actual file.
+
+Specific values might be limited by package-feature settings:
+Parameters `ttl` and `maxcount` are required, if the tariff defines a maximum limit for these values.
+The password protection feature is not available in all tariffs.
+
+Status codes:
+  - 201 - Created
+  - 400 - Bad Request (e.g. invalid parameter)
+  - 401 - Unauthorized (no authentication)
+  - 403 - Forbidden (wrong password)
+  - 404 - Not Found (e.g. ID not existing)
+  - 500 - Internal Error
+
+Supported parameters:
+  - maxcount ([Parameters.SetMaxCount])
+  - path ([Parameters.SetPath])
+  - pid ([Parameters.SetPid])
+  - password ([Parameters.SetPassword])
+  - ttl ([Parameters.SetTTL])
+  - type - always set by the method to value `file`
+*/
+func (s Sharelink) CreateShareLink(ctx context.Context, params url.Values) (*ShareObject, error) {
+	var (
+		res  *http.Response
+		body []byte
+	)
+
+	params.Set("type", "file")
+	{
+		var err error
+		if res, err = s.doPOST(ctx, "sharelink", params, []int{http.StatusCreated}, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	{
+		var err error
+		if body, err = io.ReadAll(res.Body); err != nil {
+			return nil, err
+		}
+	}
+
+	obj := &ShareObject{}
+	if err := json.Unmarshal(body, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+/*
+GetShareLink - if no "id" parameter is given, a list of all sharelink objects of the user is returned.
+With a given "id" only the corresponding `sharelink` object is returned, if that exists.
+
+Status codes:
+  - 200 - OK
+  - 400 - Bad Request (e.g. invalid parameter)
+  - 401 - Unauthorized (password required)
+  - 403 - Forbidden (wrong password)
+  - 404 - Not Found (ID does not exist or given path is not shared).
+  - 500 - Internal Error
+
+Supported parameters:
+  - id ([Parameters.SetId])
+  - fields ([Parameters.SetFields])
+*/
+func (s Sharelink) GetShareLink(ctx context.Context, params url.Values) (*ShareObject, error) {
+	var (
+		res  *http.Response
+		body []byte
+	)
+
+	{
+		var err error
+		if res, err = s.doGET(ctx, "sharelink", params, []int{http.StatusOK}); err != nil {
+			return nil, err
+		}
+	}
+
+	{
+		var err error
+		if body, err = io.ReadAll(res.Body); err != nil {
+			return nil, err
+		}
+	}
+
+	obj := &ShareObject{}
+	if err := json.Unmarshal(body, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+/*
+UpdateShareLink - update values for a given `sharelink` (not available for all tariffs).
+
+Specific values might be limited due to package-feature settings:
+  - The password protection feature is not available in all tariffs.
+  - Parameters `ttl` and `maxcount` are required, if the tariff defines a maximum limit for these values.
+  - The new value for `maxcount` must be equal to greater than the current count and the difference
+    between the value of the current `maxcount` and the new `maxcount` may be limited, depending on the tariff.
+
+Status codes:
+  - 200 - OK
+  - 400 - Bad Request (e.g. invalid parameter)
+  - 401 - Unauthorized (no authentication)
+  - 403 - Forbidden (wrong password)
+  - 404 - Not Found (e.g. ID not existing)
+  - 500 - Internal Error
+
+Supported parameters:
+  - maxcount ([Parameters.SetMaxCount])
+  - id ([Parameters.SetId])
+  - password ([Parameters.SetPassword])
+  - ttl ([Parameters.SetTTL])
+*/
+func (s Sharelink) UpdateShareLink(ctx context.Context, params url.Values) (*ShareObject, error) {
+	var (
+		res  *http.Response
+		body []byte
+	)
+
+	{
+		var err error
+		if res, err = s.doPUT(ctx, "sharelink", params, []int{http.StatusOK}, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	{
+		var err error
+		if body, err = io.ReadAll(res.Body); err != nil {
+			return nil, err
+		}
+	}
+
+	obj := &ShareObject{}
+	if err := json.Unmarshal(body, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+/*
+DeleteShareLink - remove `sharelink`.
+
+Status codes:
+  - 204 - No Content
+  - 400 - Bad Request (e.g. invalid parameter)
+  - 401 - Unauthorized
+  - 403 - Forbidden
+  - 404 - Not Found (e.g. ID not existing)
+  - 500 - Internal Error
+
+Supported parameters:
+  - id ([Parameters.SetId])
+*/
+func (s Sharelink) DeleteShareLink(ctx context.Context, params url.Values) (*ShareObject, error) {
+	var (
+		res  *http.Response
+		body []byte
+	)
+
+	{
+		var err error
+		if res, err = s.doDELETE(ctx, "sharelink", params, []int{http.StatusNoContent}); err != nil {
+			return nil, err
+		}
+	}
+
+	{
+		var err error
+		if body, err = io.ReadAll(res.Body); err != nil {
+			return nil, err
+		}
+	}
+
+	obj := &ShareObject{}
+	if err := json.Unmarshal(body, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}

--- a/types.go
+++ b/types.go
@@ -26,31 +26,32 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// HiDriveObject represents HiDrive object - directory or file
-type HiDriveObject struct {
-	Path         string           `json:"path"`
-	Type         string           `json:"type"`
-	ID           string           `json:"id"`
-	ParentID     string           `json:"parent_id"`
-	Name         string           `json:"name"`
-	Size         int64            `json:"size"`
-	MemberCount  int64            `json:"nmembers"`
-	MTime        Time             `json:"mtime"`
-	CTime        Time             `json:"ctime"`
-	MetaHash     string           `json:"mhash"`
-	MetaOnlyHash string           `json:"mohash"`
-	NHash        string           `json:"nhash"`
-	CHash        string           `json:"chash"`
-	Teamfolder   bool             `json:"teamfolder"`
-	Readable     bool             `json:"readable"`
-	Writable     bool             `json:"writable"`
-	Shareable    bool             `json:"shareable"`
-	MIMEType     string           `json:"mime_type"`
-	Members      []*HiDriveObject `json:"members"`
+// Object represents HiDrive object - directory or file
+type Object struct {
+	Path         string         `json:"path"`
+	Type         string         `json:"type"`
+	ID           string         `json:"id"`
+	ParentID     string         `json:"parent_id"`
+	Name         string         `json:"name"`
+	Size         int64          `json:"size"`
+	MemberCount  int64          `json:"nmembers"`
+	Members      []*Object      `json:"members"`
+	MTime        Time           `json:"mtime"`
+	CTime        Time           `json:"ctime"`
+	MetaHash     string         `json:"mhash"`
+	MetaOnlyHash string         `json:"mohash"`
+	NHash        string         `json:"nhash"`
+	CHash        string         `json:"chash"`
+	Teamfolder   bool           `json:"teamfolder"`
+	Readable     bool           `json:"readable"`
+	Writable     bool           `json:"writable"`
+	Shareable    bool           `json:"shareable"`
+	MIMEType     string         `json:"mime_type"`
+	RShare       []*ShareObject `json:"rshare"`
 }
 
-func (h *HiDriveObject) UnmarshalJSON(b []byte) error {
-	type HiDriveObjectAlias HiDriveObject
+func (h *Object) UnmarshalJSON(b []byte) error {
+	type HiDriveObjectAlias Object
 	defaultObject := HiDriveObjectAlias{
 		Size:        -1,
 		MemberCount: -1,
@@ -65,12 +66,12 @@ func (h *HiDriveObject) UnmarshalJSON(b []byte) error {
 		defaultObject.Name = name
 	}
 
-	*h = HiDriveObject(defaultObject)
+	*h = Object(defaultObject)
 	return nil
 }
 
-// HiDriveShareObject represents HiDrive Share object
-type HiDriveShareObject struct {
+// ShareObject represents HiDrive Share object
+type ShareObject struct {
 	ID           string `json:"id"`
 	Path         string `json:"path"`
 	Status       string `json:"status"`
@@ -95,8 +96,8 @@ type HiDriveShareObject struct {
 	Writable     bool   `json:"writable"`
 }
 
-func (s *HiDriveShareObject) UnmarshalJSON(b []byte) error {
-	type HiDriveShareObjectAlias HiDriveShareObject
+func (s *ShareObject) UnmarshalJSON(b []byte) error {
+	type HiDriveShareObjectAlias ShareObject
 	defaultObject := HiDriveShareObjectAlias{
 		Size:      -1,
 		TTL:       -1,
@@ -110,17 +111,17 @@ func (s *HiDriveShareObject) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	*s = HiDriveShareObject(defaultObject)
+	*s = ShareObject(defaultObject)
 	return nil
 }
 
-type HiDriveShareInviteStatus struct {
+type ShareInviteStatus struct {
 	To      string `json:"to"`
 	Code    int    `json:"code"`
 	Message string `json:"msg"`
 }
 
-type HiDriveShareInviteResponse struct {
-	Done   []HiDriveShareInviteStatus `json:"done"`
-	Failed []HiDriveShareInviteStatus `json:"failed"`
+type ShareInviteResponse struct {
+	Done   []ShareInviteStatus `json:"done"`
+	Failed []ShareInviteStatus `json:"failed"`
 }


### PR DESCRIPTION
Big refactoring:
* Renamed `ShareApi` -> `Share`
* Renamed `DirAPi` -> `Dir`
* Renamed `FileApi` -> `File`
* Renamed `HiDriveObject` -> `Object`
* Renamed `HiDriveShareObject` -> `ShareObject`
* Renamed `HiDriveError` -> `Error`
* Corresponding methods do not have parent structure suffixes anymore (i.e. `Dir.GetDir` is now just `Dir.Get`, `File.CreateFile` is now `File.Create` and so on)
* Decoupled `/sharelink` methods into a separate struct `Sharelink`
* Refactored doGET/POST/PUT/DELETE/PATCH methods to check for HiDrive `Error` (reduces boilerplate code)
* Added method `Api.doPATCH` to perform `PATCH` requests
* Added new struct `Meta` to implement `/meta` API endpoints requests
* Extended `Object` (former `HiDriveObject`) with new field `RShare` representing a list of share objects (used when getting response with `Meta.Get`)