### PR TITLE
v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,17 @@ You can also use `Parameters` objects to simplify parameters gathering required 
 Example reading file from HiDrive:
 
 ```go
-import "golang.org/x/oauth2"
-import hidrive "github.com/Burmuley/go-hidrive"
+package main
+
+import (
+	"log"
+	"context"
+	"io"
+	"fmt"
+
+	"golang.org/x/oauth2"
+	hidrive "github.com/Burmuley/go-hidrive"
+)
 
 func main() {
     oauth2config := oauth2.Config{
@@ -31,20 +40,19 @@ func main() {
     }
 
     client := oauth2config.Client(context.Background(), token)
-    fileApi := hidrive.NewFileApi(client, StratoHiDriveAPIV21)
+    fileApi := hidrive.NewFile(client, hidrive.StratoHiDriveAPIV21)
 
-    rdr, err := fileApi.GetFile(context.Background(), NewParameters().SetPath("/public/test_file.txt").Values)
+    rdr, err := fileApi.Get(context.Background(), hidrive.NewParameters().SetPath("/public/test_file.txt").Values)
 
     if err != nil {
-        fmt.Println(err)
-        return
+        log.Fatal(err)
     }
-	
+
     contents, err := io.ReadAll(rdr)
     if err != nil {
-        fmt.Println(err)
-        return
+        log.Fatal(err)
     }
+	
     fmt.Println(contents)
 }
 ```

--- a/api.go
+++ b/api.go
@@ -9,8 +9,17 @@ You can also use [Parameters] objects to simplify parameters gathering required 
 
 Example reading file from HiDrive:
 
-	import "golang.org/x/oauth2"
-	import hidrive "github.com/Burmuley/go-hidrive"
+	package main
+
+	import (
+		"log"
+		"context"
+		"io"
+		"fmt"
+
+		"golang.org/x/oauth2"
+		hidrive "github.com/Burmuley/go-hidrive"
+	)
 
 	func main() {
 		oauth2config := oauth2.Config{
@@ -29,20 +38,19 @@ Example reading file from HiDrive:
 		}
 
 		client := oauth2config.Client(context.Background(), token)
-		fileApi := hidrive.NewFile(client, StratoHiDriveAPIV21)
+		fileApi := hidrive.NewFile(client, hidrive.StratoHiDriveAPIV21)
 
-		rdr, err := fileApi.Get(context.Background(), NewParameters().SetPath("/public/test_file.txt").Values)
+		rdr, err := fileApi.Get(context.Background(), hidrive.NewParameters().SetPath("/public/test_file.txt").Values)
 
 		if err != nil {
-			fmt.Println(err)
-			return
+			log.Fatal(err)
 		}
 
 		contents, err := io.ReadAll(rdr)
 		if err != nil {
-			fmt.Println(err)
-			return
+			log.Fatal(err)
 		}
+
 		fmt.Println(contents)
 	}
 */
@@ -158,6 +166,21 @@ func (a Api) checkHTTPStatusError(okCodes []int, res *http.Response) error {
 			return err
 		}
 		return hdErr
+	}
+
+	return nil
+}
+
+func (a Api) unmarshalBody(res *http.Response, obj any) error {
+	var body []byte
+	var err error
+
+	if body, err = io.ReadAll(res.Body); err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(body, obj); err != nil {
+		return err
 	}
 
 	return nil

--- a/dir.go
+++ b/dir.go
@@ -3,7 +3,6 @@ package go_hidrive
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -61,30 +60,20 @@ Returns [Object] with information about given directory.
 */
 func (d Dir) Get(ctx context.Context, params url.Values) (*Object, error) {
 	var (
-		res  *http.Response
-		body []byte
+		res *http.Response
+		err error
 	)
 
-	{
-		var err error
-		if res, err = d.doGET(ctx, "dir", params, []int{http.StatusOK}); err != nil {
-			return nil, err
-		}
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
-	}
-
-	hdObj := &Object{}
-	if err := hdObj.UnmarshalJSON(body); err != nil {
+	if res, err = d.doGET(ctx, "dir", params, []int{http.StatusOK}); err != nil {
 		return nil, err
 	}
 
-	return hdObj, nil
+	obj := &Object{}
+	if err := d.unmarshalBody(res, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
 }
 
 /*
@@ -117,30 +106,20 @@ Returns [Object] with information about the directory created.
 */
 func (d Dir) Create(ctx context.Context, params url.Values) (*Object, error) {
 	var (
-		res  *http.Response
-		body []byte
+		res *http.Response
+		err error
 	)
 
-	{
-		var err error
-		if res, err = d.doPOST(ctx, "dir", params, []int{http.StatusCreated}, nil); err != nil {
-			return nil, err
-		}
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
-	}
-
-	hdObj := &Object{}
-	if err := hdObj.UnmarshalJSON(body); err != nil {
+	if res, err = d.doPOST(ctx, "dir", params, []int{http.StatusCreated}, nil); err != nil {
 		return nil, err
 	}
 
-	return hdObj, nil
+	obj := &Object{}
+	if err := d.unmarshalBody(res, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
 }
 
 /*

--- a/file.go
+++ b/file.go
@@ -49,13 +49,13 @@ Supported parameters:
 Returns an io.ReadCloser object to read file contents using standard Go mechanisms.
 */
 func (f File) Get(ctx context.Context, params url.Values) (io.ReadCloser, error) {
-	var res *http.Response
+	var (
+		res *http.Response
+		err error
+	)
 
-	{
-		var err error
-		if res, err = f.doGET(ctx, "file", params, []int{http.StatusOK}); err != nil {
-			return nil, err
-		}
+	if res, err = f.doGET(ctx, "file", params, []int{http.StatusOK}); err != nil {
+		return nil, err
 	}
 
 	return res.Body, nil
@@ -105,30 +105,20 @@ Returns [Object] with information about uploaded file.
 */
 func (f File) Upload(ctx context.Context, params url.Values, fileBody io.ReadCloser) (*Object, error) {
 	var (
-		res  *http.Response
-		body []byte
+		res *http.Response
+		err error
 	)
 
-	{
-		var err error
-		if res, err = f.doPOST(ctx, "file", params, []int{http.StatusCreated}, fileBody); err != nil {
-			return nil, err
-		}
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
-	}
-
-	hdObj := &Object{}
-	if err := hdObj.UnmarshalJSON(body); err != nil {
+	if res, err = f.doPOST(ctx, "file", params, []int{http.StatusCreated}, fileBody); err != nil {
 		return nil, err
 	}
 
-	return hdObj, nil
+	obj := &Object{}
+	if err := f.unmarshalBody(res, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
 }
 
 /*
@@ -205,28 +195,18 @@ Returns [Object] with information about uploaded file.
 */
 func (f File) Update(ctx context.Context, params url.Values, fileBody io.ReadCloser) (*Object, error) {
 	var (
-		res  *http.Response
-		body []byte
+		res *http.Response
+		err error
 	)
 
-	{
-		var err error
-		if res, err = f.doPUT(ctx, "file", params, []int{http.StatusOK}, fileBody); err != nil {
-			return nil, err
-		}
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
-	}
-
-	hdObj := &Object{}
-	if err := hdObj.UnmarshalJSON(body); err != nil {
+	if res, err = f.doPUT(ctx, "file", params, []int{http.StatusOK}, fileBody); err != nil {
 		return nil, err
 	}
 
-	return hdObj, nil
+	obj := &Object{}
+	if err := f.unmarshalBody(res, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
 }

--- a/meta.go
+++ b/meta.go
@@ -2,8 +2,6 @@ package go_hidrive
 
 import (
 	"context"
-	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 )
@@ -48,26 +46,16 @@ Supported parameters:
 */
 func (m Meta) Get(ctx context.Context, params url.Values) (*Object, error) {
 	var (
-		res  *http.Response
-		body []byte
+		res *http.Response
+		err error
 	)
 
-	{
-		var err error
-		if res, err = m.doGET(ctx, "meta", params, []int{http.StatusOK}); err != nil {
-			return nil, err
-		}
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
+	if res, err = m.doGET(ctx, "meta", params, []int{http.StatusOK}); err != nil {
+		return nil, err
 	}
 
 	obj := &Object{}
-	if err := json.Unmarshal(body, obj); err != nil {
+	if err := m.unmarshalBody(res, obj); err != nil {
 		return nil, err
 	}
 
@@ -95,26 +83,16 @@ Supported parameters:
 */
 func (m Meta) Update(ctx context.Context, params url.Values) (*Object, error) {
 	var (
-		res  *http.Response
-		body []byte
+		res *http.Response
+		err error
 	)
 
-	{
-		var err error
-		if res, err = m.doPATCH(ctx, "meta", params, []int{http.StatusOK, http.StatusNoContent}, nil); err != nil {
-			return nil, err
-		}
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
+	if res, err = m.doPATCH(ctx, "meta", params, []int{http.StatusOK, http.StatusNoContent}, nil); err != nil {
+		return nil, err
 	}
 
 	obj := &Object{}
-	if err := json.Unmarshal(body, obj); err != nil {
+	if err := m.unmarshalBody(res, obj); err != nil {
 		return nil, err
 	}
 

--- a/params.go
+++ b/params.go
@@ -26,6 +26,9 @@ Can be used in the following methods:
   - [File.Delete]
   - [Share.Get]
   - [Share.Create]
+  - [Sharelink.Create]
+  - [Meta.Get]
+  - [Meta.Update]
 */
 func (p *Parameters) SetPath(path string) *Parameters {
 	p.Set("path", path)
@@ -46,6 +49,9 @@ Can be used in the following methods:
   - [File.Delete]
   - [Share.Get]
   - [Share.Create]
+  - [Sharelink.Create]
+  - [Meta.Get]
+  - [Meta.Update]
 */
 func (p *Parameters) SetPid(pid string) *Parameters {
 	p.Set("pid", pid)
@@ -98,6 +104,8 @@ Therefore, it is recommended to use a "need to know" approach instead of "get al
 Can be used in the following methods:
   - [Dir.Get]
   - [Share.Get]
+  - [Sharelink.Get]
+  - [Meta.Get]
 
 Valid values for [Dir.Get]:
   - category                - string    - object category (audio, image, etc.)
@@ -238,6 +246,7 @@ to be set after the operation.
 Can be used in the following methods:
   - [Dir.Create]
   - [File.Upload]
+  - [Meta.Update]
 */
 func (p *Parameters) SetMTime(t time.Time) *Parameters {
 	timeStr := fmt.Sprint(t.Unix())
@@ -352,6 +361,8 @@ value permissible.
 
 Can be used in the following methods:
   - [Share.Create]
+  - [Sharelink.Create]
+  - [Sharelink.Update]
 */
 func (p *Parameters) SetMaxCount(count int) *Parameters {
 	p.Set("maxcount", fmt.Sprint(count))
@@ -366,6 +377,8 @@ This parameter must be omitted for encrypted shares which require salt, share_ac
 
 Can be used in the following methods:
   - [Share.Create]
+  - [Sharelink.Create]
+  - [Sharelink.Update]
 */
 func (p *Parameters) SetPassword(password string) *Parameters {
 	p.Set("password", password)
@@ -392,6 +405,8 @@ A positive number defining seconds from now. Not specifying a value sets ttl to 
 
 Can be used in the following methods:
   - [Share.Create]
+  - [Sharelink.Create]
+  - [Sharelink.Update]
 */
 func (p *Parameters) SetTTL(ttl uint) *Parameters {
 	p.Set("ttl", fmt.Sprint(ttl))
@@ -444,6 +459,10 @@ SetId - adds "id" parameter to the request - a share id as returned by [Share.Ge
 
 Can be used in the following methods:
   - [Share.Create]
+  - [Sharelink.Get]
+  - [Sharelink.Create]
+  - [Sharelink.Update]
+  - [Sharelink.Delete]
 */
 func (p *Parameters) SetId(id string) *Parameters {
 	p.Set("id", id)

--- a/share.go
+++ b/share.go
@@ -2,8 +2,6 @@ package go_hidrive
 
 import (
 	"context"
-	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 )
@@ -46,26 +44,16 @@ Supported parameters:
 */
 func (s Share) Get(ctx context.Context, params url.Values) (*ShareObject, error) {
 	var (
-		res  *http.Response
-		body []byte
+		res *http.Response
+		err error
 	)
 
-	{
-		var err error
-		if res, err = s.doGET(ctx, "share", params, []int{http.StatusOK}); err != nil {
-			return nil, err
-		}
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
+	if res, err = s.doGET(ctx, "share", params, []int{http.StatusOK}); err != nil {
+		return nil, err
 	}
 
 	obj := &ShareObject{}
-	if err := json.Unmarshal(body, &obj); err != nil {
+	if err := s.unmarshalBody(res, obj); err != nil {
 		return nil, err
 	}
 
@@ -105,31 +93,20 @@ Supported parameters:
 */
 func (s Share) Create(ctx context.Context, params url.Values) (*ShareObject, error) {
 	var (
-		res  *http.Response
-		body []byte
+		res *http.Response
+		err error
 	)
 
-	{
-		var err error
-		if res, err = s.doPOST(ctx, "share", params, []int{http.StatusCreated}, nil); err != nil {
-			return nil, err
-		}
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
+	if res, err = s.doPOST(ctx, "share", params, []int{http.StatusCreated}, nil); err != nil {
+		return nil, err
 	}
 
 	obj := &ShareObject{}
-	if err := obj.UnmarshalJSON(body); err != nil {
+	if err := s.unmarshalBody(res, obj); err != nil {
 		return nil, err
 	}
 
 	return obj, nil
-
 }
 
 /*
@@ -180,26 +157,16 @@ Supported parameters:
 */
 func (s Share) Update(ctx context.Context, params url.Values) (*ShareObject, error) {
 	var (
-		res  *http.Response
-		body []byte
+		res *http.Response
+		err error
 	)
 
-	{
-		var err error
-		if res, err = s.doPUT(ctx, "share", params, []int{http.StatusOK}, nil); err != nil {
-			return nil, err
-		}
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
+	if res, err = s.doPUT(ctx, "share", params, []int{http.StatusOK}, nil); err != nil {
+		return nil, err
 	}
 
 	obj := &ShareObject{}
-	if err := obj.UnmarshalJSON(body); err != nil {
+	if err := s.unmarshalBody(res, obj); err != nil {
 		return nil, err
 	}
 
@@ -236,26 +203,16 @@ Failure- and done-objects will then contain the individual status of each proces
 */
 func (s Share) Invite(ctx context.Context, params url.Values) (*ShareInviteResponse, error) {
 	var (
-		res  *http.Response
-		body []byte
+		res *http.Response
+		err error
 	)
 
-	{
-		var err error
-		if res, err = s.doPOST(ctx, "share/invite", params, []int{http.StatusOK, http.StatusMultiStatus}, nil); err != nil {
-			return nil, err
-		}
-	}
-
-	{
-		var err error
-		if body, err = io.ReadAll(res.Body); err != nil {
-			return nil, err
-		}
+	if res, err = s.doPOST(ctx, "share/invite", params, []int{http.StatusOK, http.StatusMultiStatus}, nil); err != nil {
+		return nil, err
 	}
 
 	obj := &ShareInviteResponse{}
-	if err := json.Unmarshal(body, obj); err != nil {
+	if err := s.unmarshalBody(res, obj); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
* Fixed `NewSharelink` function to return `Sharelink` object
* Renamed `Sharelink` method to follow common pattern: `CreateShareLink` -> `Create`, `UpdateShareLink` -> `Update`, `GetShareLInk` -> `Get`, `DeleteShareLink` -> `Delete`
* Updated documentation
* Refactored response reading to reduce boilerplate code